### PR TITLE
Fix service worker paths without placeholder icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
       if('serviceWorker' in navigator){
         const swCode = `
           const CACHE = 'caleb-cloze-cache-v2';
-          const OFFLINE_URL = '/offline.html';
-          const CORE = [ self.location.href, OFFLINE_URL, '/icons/icon-192.png', '/icons/icon-512.png' ];
+          const OFFLINE_URL = 'offline.html';
+          const CORE = [ self.location.href, OFFLINE_URL, 'icons/icon-192.png', 'icons/icon-512.png' ];
 
           const OFFLINE_HTML = ` + "`" + `<!doctype html>
           <html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>Learn2Read</title>


### PR DESCRIPTION
## Summary
- use relative URLs for offline page and PWA icons in service worker
- remove placeholder icon files, keeping existing placeholder file intact

## Testing
- `python3 -m http.server 8000`
- `curl -I http://localhost:8000/`
- `curl -I http://localhost:8000/icons/1`


------
https://chatgpt.com/codex/tasks/task_e_689b845371308331985bdffdc4eed0a8